### PR TITLE
The usage of the @filename API for file uploading is deprecated. Please use the CURLFile class instead.

### DIFF
--- a/src/Zendesk/API/Attachments.php
+++ b/src/Zendesk/API/Attachments.php
@@ -24,7 +24,7 @@ class Attachments extends ClientAbstract {
             throw new MissingParametersException(__METHOD__, array('postname'));
         }
         if(!file_exists($params['filename'])) {
-            throw new CustomException('File '.$params['file'].' could not be found in '.__METHOD__);
+            throw new CustomException('File '.$params['filename'].' could not be found in '.__METHOD__);
         }
 
         $endPoint = Http::prepare('uploads.json?filename=' . urlencode($params['postname']) . (isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));

--- a/src/Zendesk/API/Attachments.php
+++ b/src/Zendesk/API/Attachments.php
@@ -10,20 +10,25 @@ class Attachments extends ClientAbstract {
     /*
      * Upload an attachment
      * $params must include:
-     *    'file' - an attribute with the absolute local file path on the server
-     *    'type' - the MIME type of the file
+     *    'filename' - an attribute with the absolute local file path on the server
+     *    'postname' - the name of posted file
      * Optional:
      *    'optional_token' - an existing token
      */
-    public function upload(array $params) {
-        if(!$this->hasKeys($params, array('file'))) {
-            throw new MissingParametersException(__METHOD__, array('file'));
+    public function upload(array $params)
+    {
+        if(!$this->hasKeys($params, array('filename'))) {
+            throw new MissingParametersException(__METHOD__, array('filename'));
         }
-        if(!file_exists($params['file'])) {
+        if(!$this->hasKeys($params, array('postname'))) {
+            throw new MissingParametersException(__METHOD__, array('postname'));
+        }
+        if(!file_exists($params['filename'])) {
             throw new CustomException('File '.$params['file'].' could not be found in '.__METHOD__);
         }
-        $endPoint = Http::prepare('uploads.json?filename='.$params['file'].(isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));
-        $response = Http::send($this->client, $endPoint, array('filename' => '@'.$params['file']), 'POST', (isset($params['type']) ? $params['type'] : 'application/binary'));
+
+        $endPoint = Http::prepare('uploads.json?filename=' . urlencode($params['postname']) . (isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));
+        $response = Http::send($this->client, $endPoint, file_get_contents($params['filename']), 'POST', 'application/binary');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -35,23 +35,23 @@ class Http {
     /*
      * Use the send method to call every endpoint except for oauth/tokens
      */
-    public static function send($client, $endPoint, $json = null, $method = 'GET', $contentType = 'application/json') {
+    public static function send($client, $endPoint, $data = null, $method = 'GET', $contentType = 'application/json') {
 
         $url = $client->getApiUrl().$endPoint;
         $method = strtoupper($method);
-        $json = ($json == null ? (object) null : (($method != 'GET') && ($method != 'DELETE') && ($contentType == 'application/json') ? json_encode($json) : $json));
+        $data = ($data == null ? (object) null : (($method != 'GET') && ($method != 'DELETE') && ($contentType == 'application/json') ? json_encode($data) : $data));
 
         if($method == 'POST') {
             $curl = curl_init($url);
             curl_setopt($curl, CURLOPT_POST, true);
-            curl_setopt($curl, CURLOPT_POSTFIELDS, $json);
+            curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
         } else
         if($method == 'PUT') {
             $curl = curl_init($url);
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
-            curl_setopt($curl, CURLOPT_POSTFIELDS, $json);
+            curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
         } else {
-            $curl = curl_init($url.($json != (object) null ? '?'.http_build_query($json) : ''));
+            $curl = curl_init($url.($data != (object) null ? '?'.http_build_query($data) : ''));
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, ($method ? $method : 'GET'));
         }
         if($client->getAuthType() == 'oauth_token') {


### PR DESCRIPTION
In PHP 5.5, the @filename method of sending a file using CURL has been deprecated.
Using @filename method to send a file causes exception:
`curl_setopt(): The usage of the @filename API for file uploading is deprecated. Please use the CURLFile class instead`

The possible solution is to pass file content directly to CURL post fields.
